### PR TITLE
bump mincer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,13 @@
     "uglify-js": "2.4.23"
   },
   "devDependencies": {
-    "mocha": "2.2.5",
     "blanket": "1.1.7",
-    "expect.js": "0.3.1",
-    "travis-cov": "0.2.5",
     "connect": "3.4.0",
-    "ejs": "1.0.0"
+    "ejs": "1.0.0",
+    "expect.js": "0.3.1",
+    "mocha": "2.2.5",
+    "postcss": "^5.0.14",
+    "travis-cov": "0.2.5"
   },
   "config": {
     "travis-cov": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "argparse": "1.0.2",
     "csswring": "3.0.5",
     "mime": "1.3.4",
-    "mincer": "1.3.1",
+    "mincer": "1.4.1",
     "uglify-js": "2.4.23"
   },
   "devDependencies": {

--- a/test/bin.connect-assets.js
+++ b/test/bin.connect-assets.js
@@ -93,7 +93,7 @@ describe("connect-assets command-line interface", function () {
 
       var css = dir + '/' + manifest.assets['asset-path-helper.css'];
 
-      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"/assets/asset-b2d7f14c5810c3ee6b519c317297190e.css\"");
+      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"/assets/asset-e89e45b0019f8d3feb5341de6b815cdb.css\"");
       rmrf("builtAssets", done);
     });
   });
@@ -108,7 +108,7 @@ describe("connect-assets command-line interface", function () {
 
       var css = dir + '/' + manifest.assets['asset-path-helper.css'];
 
-      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"//cdn.example.com/asset-b2d7f14c5810c3ee6b519c317297190e.css\"");
+      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"//cdn.example.com/asset-e89e45b0019f8d3feb5341de6b815cdb.css\"");
       rmrf("builtAssets", done);
     });
   });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -57,7 +57,7 @@ describe("helper functions", function () {
     var instance = assets({ helperContext: ctx, paths: "test/assets/css", fingerprinting: true });
     var files = ctx.assetPath("blank.css");
 
-    expect(files).to.equal("/assets/blank-b2d7f14c5810c3ee6b519c317297190e.css");
+    expect(files).to.equal("/assets/blank-e89e45b0019f8d3feb5341de6b815cdb.css");
   });
 
   describe("css", function () {

--- a/test/serveAsset.asset_path-helper.js
+++ b/test/serveAsset.asset_path-helper.js
@@ -13,14 +13,14 @@ describe("serveAsset asset_path environment helper", function () {
 
     createServer.call(this, { buildDir: dir, compile: true, fingerprinting: true }, function () {
       var path = this.assetPath("asset-path-helper.css");
-      var filename = dir + "/asset-path-helper-c7c84865f023738e66a7b02353c5d6c3.css";
+      var filename = dir + "/asset-path-helper-ecc5d891145d56a0274eb4f34670671e.css";
       var url = this.host + path;
 
       http.get(url, function (res) {
         expect(res.statusCode).to.equal(200);
         expect(fs.statSync(dir).isDirectory()).to.equal(true);
         expect(fs.statSync(filename).isFile()).to.equal(true);
-        expect(fs.readFileSync(filename, "utf8")).to.equal("@import \"/assets/asset-b2d7f14c5810c3ee6b519c317297190e.css\";\n\n");
+        expect(fs.readFileSync(filename, "utf8")).to.equal("@import \"/assets/asset-e89e45b0019f8d3feb5341de6b815cdb.css\";\n\n");
 
         process.env.NODE_ENV = env;
         rmrf(dir, done);

--- a/test/serveAsset.filesystem.js
+++ b/test/serveAsset.filesystem.js
@@ -67,7 +67,7 @@ describe("serveAsset filesystem", function () {
         http.get(url, function (res) {
           expect(res.statusCode).to.equal(200);
           expect(fs.statSync(dir).isDirectory()).to.equal(true);
-          expect(fs.statSync(dir + "/blank-54acb57afb70110fb7f8e1de35e176b4.css").isFile()).to.equal(true);
+          expect(fs.statSync(dir + "/blank-1e6dbfaaa068a191cfd257c013ddd699.css").isFile()).to.equal(true);
 
           process.env.NODE_ENV = env;
           rmrf(dir, done);

--- a/test/serveAsset.minification.js
+++ b/test/serveAsset.minification.js
@@ -14,7 +14,7 @@ describe("serveAsset minification", function () {
 
     createServer.call(this, { buildDir: dir }, function () {
       var path = this.assetPath("unminified.js");
-      var filename = dir + "/unminified-1e56447a8040d5d20e645c14b60843d3.js";
+      var filename = dir + "/unminified-7f7c719c7128b10ce7400464787a795c.js";
       var url = this.host + path;
 
       http.get(url, function (res) {
@@ -36,7 +36,7 @@ describe("serveAsset minification", function () {
 
     createServer.call(this, { buildDir: dir }, function () {
       var path = this.assetPath("unminified.css");
-      var filename = dir + "/unminified-918ac6d6065eb5d5579144f3444e13f2.css";
+      var filename = dir + "/unminified-f34e2abf5b7497977195904e60f06031.css";
       var url = this.host + path;
 
       http.get(url, function (res) {


### PR DESCRIPTION
@OverFlow636 

bump mincer version to use `autoprefixor`, old version of mincer was using `autoprefixor-core`, which is deprecated. 
