### PR TITLE
chore: Updated dependencies

### DIFF
--- a/bin/connect-assets
+++ b/bin/connect-assets
@@ -7,8 +7,7 @@ var mincer = require("mincer");
 var initialize = exports.initialize = function () {
   var cli = new ArgumentParser({
     prog: "connect-assets",
-    version: require("../package.json").version,
-    addHelp: true,
+    add_help: true,
     description: "Precompiles assets supplied into their production-ready " +
       "form, ready for upload to a CDN or static file server. The generated " +
       "manifest.json is all that is required on your application server if " +
@@ -18,49 +17,54 @@ var initialize = exports.initialize = function () {
       "source of this file for help)."
   });
 
-  cli.addArgument(["-i", "--include"], {
+  cli.add_argument('-v', '--version', {
+    action: 'version',
+    version: require("../package.json").version
+  });
+
+  cli.add_argument("-i", "--include", {
     help: "Adds the directory to a list of directories that assets will be " +
       "read from, in order of preference. Defaults to 'assets/js' and " +
       "'assets/css'.",
     metavar: "DIRECTORY",
     action: "append",
     nargs: "*",
-    defaultValue: [ "assets/js", "assets/css" ]
+    default: [ "assets/js", "assets/css" ]
   });
 
-  cli.addArgument(["-c", "--compile"], {
+  cli.add_argument("-c", "--compile", {
     help: "Adds the file (or pattern) to a list of files to compile. " +
       "Defaults to all files with extensions.",
     metavar: "FILE",
     action: "append",
     nargs: "*",
-    defaultValue: ["*.*"]
+    default: ["*.*"]
   });
 
-  cli.addArgument(["-o", "--output"], {
+  cli.add_argument("-o", "--output", {
     help: "Specifies the output directory to write compiled assets to. " +
       "Defaults to 'builtAssets'.",
     metavar: "DIRECTORY",
-    defaultValue: "builtAssets"
+    default: "builtAssets"
   });
 
-  cli.addArgument(["-s", "--servePath"], {
+  cli.add_argument("-s", "--servePath", {
     help: "The virtual path in which assets will be served over HTTP. " +
       "If hosting assets locally, supply a local path (say, \"assets\"). " +
       "If hosting assets remotely on a CDN, supply a URL.",
-    defaultValue: "assets"
+    default: "assets"
   });
 
-  cli.addArgument(["-gz", "--gzip"], {
+  cli.add_argument("-gz", "--gzip", {
     help: "Enables gzip file generation, which is disabled by default.",
-    action: 'storeTrue',
-    defaultValue: false
+    action: 'store_true',
+    default: false
   });
 
-  cli.addArgument(["-ap", "--autoprefixer"], {
+  cli.add_argument("-ap", "--autoprefixer", {
     help: "Enables autoprefixer during compilation.",
-    action: 'storeTrue',
-    defaultValue: false
+    action: 'store_true',
+    default: false
   });
 
   return cli;
@@ -75,7 +79,7 @@ var execute = exports.execute = function (logger, callback) {
 };
 
 var prepare = exports.prepare = function (cli) {
-  var args = cli.parseArgs();
+  var args = cli.parse_args();
 
   args.include = flatten(args.include);
   args.compile = flatten(args.compile);

--- a/package.json
+++ b/package.json
@@ -35,18 +35,18 @@
     "connect-assets": "bin/connect-assets"
   },
   "dependencies": {
-    "argparse": "1.0.2",
+    "argparse": "^2.0.1",
     "csswring": "3.0.5",
-    "mime": "1.3.4",
-    "mincer": "1.4.1",
-    "uglify-js": "2.4.23"
+    "mime": "^1.3.4",
+    "mincer": "^2.0.1",
+    "uglify-js": "^2.6.0"
   },
   "devDependencies": {
     "blanket": "1.1.7",
-    "connect": "3.4.0",
+    "connect": "^3.7.0",
     "ejs": "1.0.0",
     "expect.js": "0.3.1",
-    "mocha": "2.2.5",
+    "mocha": "^2.4.5",
     "postcss": "^5.0.14",
     "travis-cov": "0.2.5"
   },

--- a/test/bin.connect-assets.js
+++ b/test/bin.connect-assets.js
@@ -38,7 +38,7 @@ describe("connect-assets command-line interface", function () {
       var js = dir + '/' + manifest.assets['unminified.js'];
 
       expect(fs.readFileSync(css, "utf8")).to.equal("body{background-color:#000;color:#fff}a{display:none}");
-      expect(fs.readFileSync(js, "utf8")).to.equal('!function(){var n="A string",a={aLongKeyName:function(){return n}};a.aLongKeyName()}();');
+      expect(fs.readFileSync(js, "utf8")).to.equal('!function(){var n={aLongKeyName:function(){return"A string"}};n.aLongKeyName()}();');
 
       rmrf("builtAssets", done);
     });
@@ -93,7 +93,7 @@ describe("connect-assets command-line interface", function () {
 
       var css = dir + '/' + manifest.assets['asset-path-helper.css'];
 
-      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"/assets/asset-e89e45b0019f8d3feb5341de6b815cdb.css\"");
+      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"/assets/asset-311f5bba9037308eec0e9f402dd38009.css\"");
       rmrf("builtAssets", done);
     });
   });
@@ -108,7 +108,7 @@ describe("connect-assets command-line interface", function () {
 
       var css = dir + '/' + manifest.assets['asset-path-helper.css'];
 
-      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"//cdn.example.com/asset-e89e45b0019f8d3feb5341de6b815cdb.css\"");
+      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"//cdn.example.com/asset-311f5bba9037308eec0e9f402dd38009.css\"");
       rmrf("builtAssets", done);
     });
   });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -57,7 +57,7 @@ describe("helper functions", function () {
     var instance = assets({ helperContext: ctx, paths: "test/assets/css", fingerprinting: true });
     var files = ctx.assetPath("blank.css");
 
-    expect(files).to.equal("/assets/blank-e89e45b0019f8d3feb5341de6b815cdb.css");
+    expect(files).to.equal("/assets/blank-311f5bba9037308eec0e9f402dd38009.css");
   });
 
   describe("css", function () {

--- a/test/serveAsset.asset_path-helper.js
+++ b/test/serveAsset.asset_path-helper.js
@@ -13,14 +13,14 @@ describe("serveAsset asset_path environment helper", function () {
 
     createServer.call(this, { buildDir: dir, compile: true, fingerprinting: true }, function () {
       var path = this.assetPath("asset-path-helper.css");
-      var filename = dir + "/asset-path-helper-ecc5d891145d56a0274eb4f34670671e.css";
+      var filename = dir + "/asset-path-helper-a7d0f075aca0d6e40a2d8927244142e3.css";
       var url = this.host + path;
 
       http.get(url, function (res) {
         expect(res.statusCode).to.equal(200);
         expect(fs.statSync(dir).isDirectory()).to.equal(true);
         expect(fs.statSync(filename).isFile()).to.equal(true);
-        expect(fs.readFileSync(filename, "utf8")).to.equal("@import \"/assets/asset-e89e45b0019f8d3feb5341de6b815cdb.css\";\n\n");
+        expect(fs.readFileSync(filename, "utf8")).to.equal("@import \"/assets/asset-311f5bba9037308eec0e9f402dd38009.css\";\n\n");
 
         process.env.NODE_ENV = env;
         rmrf(dir, done);

--- a/test/serveAsset.filesystem.js
+++ b/test/serveAsset.filesystem.js
@@ -67,7 +67,7 @@ describe("serveAsset filesystem", function () {
         http.get(url, function (res) {
           expect(res.statusCode).to.equal(200);
           expect(fs.statSync(dir).isDirectory()).to.equal(true);
-          expect(fs.statSync(dir + "/blank-1e6dbfaaa068a191cfd257c013ddd699.css").isFile()).to.equal(true);
+          expect(fs.statSync(dir + "/blank-47354877541923135499c38a6606138a.css").isFile()).to.equal(true);
 
           process.env.NODE_ENV = env;
           rmrf(dir, done);

--- a/test/serveAsset.headers.js
+++ b/test/serveAsset.headers.js
@@ -132,11 +132,11 @@ describe("serveAsset headers", function () {
     it("sends HTTP 405 when method is PUT", sends405("PUT"));
     it("sends HTTP 405 when method is DELETE", sends405("DELETE"));
 
-    it("sends HTTP 400 if request contains '..'", function (done) {
+    it("sends HTTP 404 if request contains '..'", function (done) {
       var url = this.host + "/assets/../../../usr/var";
 
       http.get(url, function (res) {
-        expect(res.statusCode).to.equal(400);
+        expect(res.statusCode).to.equal(404);
         done();
       });
     });

--- a/test/serveAsset.minification.js
+++ b/test/serveAsset.minification.js
@@ -14,14 +14,14 @@ describe("serveAsset minification", function () {
 
     createServer.call(this, { buildDir: dir }, function () {
       var path = this.assetPath("unminified.js");
-      var filename = dir + "/unminified-7f7c719c7128b10ce7400464787a795c.js";
+      var filename = dir + "/unminified-37ee36308d9eb1f62918b6f5ee07ca70.js";
       var url = this.host + path;
 
       http.get(url, function (res) {
         expect(res.statusCode).to.equal(200);
         expect(fs.statSync(dir).isDirectory()).to.equal(true);
         expect(fs.statSync(filename).isFile()).to.equal(true);
-        expect(fs.readFileSync(filename, "utf8")).to.equal('!function(){var n="A string",a={aLongKeyName:function(){return n}};a.aLongKeyName()}();');
+        expect(fs.readFileSync(filename, "utf8")).to.equal('!function(){var n={aLongKeyName:function(){return"A string"}};n.aLongKeyName()}();');
 
         process.env.NODE_ENV = env;
         rmrf(dir, done);
@@ -36,7 +36,7 @@ describe("serveAsset minification", function () {
 
     createServer.call(this, { buildDir: dir }, function () {
       var path = this.assetPath("unminified.css");
-      var filename = dir + "/unminified-f34e2abf5b7497977195904e60f06031.css";
+      var filename = dir + "/unminified-c6a884d1db05607b788c9b955433014e.css";
       var url = this.host + path;
 
       http.get(url, function (res) {

--- a/test/serveAsset.sourcemaps.js
+++ b/test/serveAsset.sourcemaps.js
@@ -25,14 +25,14 @@ describe("serveAsset sourcemaps", function () {
     createServer.call(this, { build: true, compress: true, sourceMaps: true }, function () {
       var path = this.assetPath("unminified.js");
       var url = this.host + path + ".map";
-      
+
       http.get(url, function (res) {
         res.setEncoding("utf8");
         var body = "";
         res.on("data", function (chunk) { body += chunk });
         res.on("end", function () {
           expect(res.statusCode).to.equal(200);
-          expect(body).to.equal("{\"version\":3,\"file\":null,\"sources\":[\"test/assets/js/unminified.js\"],\"names\":[\"aVeryLongVariableName\",\"someFunctions\",\"aLongKeyName\"],\"mappings\":\"AAAA,CAAA,WACA,GAAAA,GAAA,WAEAC,GACAC,aAAA,WACA,MAAAF,IAGAC,GAAAC;AAPA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA\",\"sourcesContent\":[\"(function () {\\n  var aVeryLongVariableName = \\\"A string\\\";\\n\\n  var someFunctions = {\\n    aLongKeyName: function () {\\n      return aVeryLongVariableName;\\n    }\\n  };\\n  var x = someFunctions.aLongKeyName();\\n})();\"],\"sourceRoot\":\"/\"}")
+          expect(body).to.equal("{\"version\":3,\"sources\":[\"test/assets/js/unminified.js\"],\"names\":[\"someFunctions\",\"aLongKeyName\"],\"mappings\":\"CAAA,WACA,GAEAA,IACAC,aAAA,WACA,MAJA,YAOAD,GAAAC\",\"file\":\"unminified.js\",\"sourcesContent\":[\"(function () {\\n  var aVeryLongVariableName = \\\"A string\\\";\\n\\n  var someFunctions = {\\n    aLongKeyName: function () {\\n      return aVeryLongVariableName;\\n    }\\n  };\\n  var x = someFunctions.aLongKeyName();\\n})();\"],\"sourceRoot\":\"/\"}")
           done();
         });
       });


### PR DESCRIPTION
Notable changes:
Mincer, which is exported, upgraded to ^2.0.1
For some reason there's a test for the status code http.get returns when there is '..' in the url. This now returns a 404 instead of a 400.
argparser upgraded to ^2.0.1. Only used in bin/connect-assets and seems mostly compatible with previous versions, with a few renames needed.
Other upgrades are for dev dependencies or just makes it match the versioning in other modules.

Audits still failing:
lodash version included by mincer
Various mocha dependencies, but mocha is a devDependency